### PR TITLE
PHPUnit does not count classes with 0 methods as covered

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+/vendor
+/composer.lock

--- a/teamcity-clover.php
+++ b/teamcity-clover.php
@@ -35,7 +35,8 @@ if (!$metrics) {
 
 $coveredClasses = 0;
 foreach ($cloverXml->xpath('//class') as $class) {
-    if ((int) $class->metrics['coveredmethods'] === (int) $class->metrics['methods']) {
+    $methods = (int) $class->metrics['methods'];
+    if ($methods > 0 && $methods === (int) $class->metrics['coveredmethods']) {
         $coveredClasses++;
     }
 }


### PR DESCRIPTION
PHPUnit does not count classes with 0 methods as covered
![image](https://user-images.githubusercontent.com/102297/42502596-2dc313bc-843f-11e8-8b04-87c20df231b8.png)
In cases there are classes with no methods in clover report, script generates incorrect value for number of covered classes (it reports more than in html report for example) and classes coverage percentage goes higher.